### PR TITLE
fscrypt: resolve some cherry-pick bugs

### DIFF
--- a/fs/ext4/ext4.h
+++ b/fs/ext4/ext4.h
@@ -36,9 +36,6 @@
 #include <linux/compat.h>
 #endif
 
-#define __FS_HAS_ENCRYPTION IS_ENABLED(CONFIG_EXT4_FS_ENCRYPTION)
-#include <linux/fscrypt.h>
-
 /*
  * The fourth extended filesystem constants/structures
  */

--- a/include/linux/fscrypt.h
+++ b/include/linux/fscrypt.h
@@ -49,17 +49,6 @@ struct fscrypt_symlink_data {
 	char encrypted_path[1];
 } __packed;
 
-/**
- * This function is used to calculate the disk space required to
- * store a filename of length l in encrypted symlink format.
- */
-static inline u32 fscrypt_symlink_data_len(u32 l)
-{
-	if (l < FS_CRYPTO_BLOCK_SIZE)
-		l = FS_CRYPTO_BLOCK_SIZE;
-	return (l + sizeof(struct fscrypt_symlink_data) - 1);
-}
-
 struct fscrypt_str {
 	unsigned char *name;
 	u32 len;


### PR DESCRIPTION
- remove wrong linux/fscrypt.h declared in ext4
- remove obsolete function

Fixes: 734f0d241d2b ("fscrypt: clean up include file mess")
Signed-off-by: Jaegeuk Kim <jaegeuk@kernel.org>